### PR TITLE
Driver order history statistics

### DIFF
--- a/src/modules/orders/controllers/v1/order.controller.js
+++ b/src/modules/orders/controllers/v1/order.controller.js
@@ -7,8 +7,12 @@ import {
   updateOrderInfo,
   getOrderById,
   getAllOrders,
+  getOrdersStatistics,
 } from '../../services/v1/order.service.js';
-import { unauthorized } from '#shared/errors/error.js';
+import { notFound, unauthorized } from '#shared/errors/error.js';
+import { ROLES } from '#shared/utils/enums.js';
+import { fetchDriverByUserId } from '#modules/drivers/index.js';
+import { DtoService } from '#shared/utils/dtoService.js';
 
 export const createOrder = async (req, res) => {
   if (!req.user) throw unauthorized();
@@ -63,6 +67,26 @@ export const cancelOrder = async (req, res) => {
   res.status(200).json({ success: true, data: updatedOrder });
 };
 
+export const ordersStatistics = async (req, res) => {
+  if (!req.user) throw unauthorized();
+
+  let driverId = null;
+  // If request come from driver, we find the current driver Id to ensure that driver only see his own data.
+  if (req.user.role === ROLES.DRIVER) {
+    const driver = await fetchDriverByUserId(req.user._id);
+    if (!driver) throw notFound('driver');
+    driverId = driver._id;
+  }
+  // Request come from admin, so we check the query parameter for driverId, if null, meaning admin want to see all orders statistics data.
+  else if (req.query?.driverId) {
+    driverId = req.query?.driverId;
+  }
+
+  const statistics = await getOrdersStatistics(driverId);
+
+  res.status(200).json({ success: true, data: statistics });
+};
+
 export const getOrders = async (req, res) => {
   if (!req.user) throw unauthorized();
 
@@ -80,7 +104,18 @@ export const getOrders = async (req, res) => {
     endDate: req.query?.endDate,
   };
 
-  const { orders, totalOrders, totalPage } = await getAllOrders(page, limit, searchQuery);
+  const isDriver = req.user.role === ROLES.DRIVER;
+
+  // If the request come from driver, so we inject the current driverId into the searchQuery to ensure that driver only see his own orders
+  if (isDriver) {
+    const driver = await fetchDriverByUserId(req.user._id);
+    if (!driver) throw notFound('driver');
+    searchQuery.driverId = driver._id;
+  }
+
+  let { orders, totalOrders, totalPage } = await getAllOrders(page, limit, searchQuery);
+
+  if (isDriver) orders = orders.map((order) => DtoService.order(order));
 
   res.status(200).json({
     success: true,

--- a/src/modules/orders/dto/order-statistics-query-validator.js
+++ b/src/modules/orders/dto/order-statistics-query-validator.js
@@ -1,0 +1,28 @@
+import z from 'zod';
+import { ERROR_CODES } from '#shared/errors/customCodes.js';
+import mongoose from 'mongoose';
+
+const queryValidator = z.object({
+  query: z.object({
+    driverId: z
+      .string()
+      .optional()
+      .transform((val) => {
+        if (!val || val.trim() === '') return undefined;
+        return val;
+      })
+      .refine(
+        (val) => {
+          if (!val) return true;
+          return mongoose.Types.ObjectId.isValid(val);
+        },
+        {
+          message: ERROR_CODES.INVALID_DRIVER_ID,
+        }
+      ),
+  }),
+});
+
+export const orderStatisticsQueryValidator = (req) => {
+  return queryValidator.safeParse({ query: req.query });
+};

--- a/src/modules/orders/index.js
+++ b/src/modules/orders/index.js
@@ -8,6 +8,7 @@ export {
   cancelOrder,
   getOrders,
   getOrder,
+  ordersStatistics,
 } from './controllers/v1/order.controller.js';
 export {
   addOrder,
@@ -20,5 +21,6 @@ export {
   getAllOrders,
   increaseDriverIndex,
   addDriversDataInOrder,
+  getOrdersStatistics,
 } from './services/v1/order.service.js';
 export { OrderModel } from './models/order.model.js';

--- a/src/modules/orders/routes/v1/order.routes.js
+++ b/src/modules/orders/routes/v1/order.routes.js
@@ -7,6 +7,7 @@ import {
   getOrders,
   pickupOrder,
   updateOrder,
+  ordersStatistics,
 } from '../../controllers/v1/order.controller.js';
 import { asyncHandler } from '#shared/middleware/asyncHandler.js';
 import express from 'express';
@@ -18,6 +19,7 @@ import { assignDriverValidator, cancelOrderValidator } from '../../dto/order-act
 import { orderQueryValidator } from '#modules/orders/dto/order-query-validator.js';
 import { authorizeRole } from '#shared/middleware/authorizeRole.js';
 import { ROLES } from '#shared/utils/enums.js';
+import { orderStatisticsQueryValidator } from '../../dto/order-statistics-query-validator.js';
 
 const router = express.Router();
 
@@ -60,7 +62,18 @@ router.put(
   validate(updateOrderValidator),
   asyncHandler(updateOrder)
 );
-router.get('/', authorizeRole(ROLES.ADMIN), validate(orderQueryValidator), asyncHandler(getOrders));
+router.get(
+  '/',
+  authorizeRole(ROLES.ADMIN, ROLES.DRIVER),
+  validate(orderQueryValidator),
+  asyncHandler(getOrders)
+);
+router.get(
+  '/statistics',
+  authorizeRole(ROLES.ADMIN, ROLES.DRIVER),
+  validate(orderStatisticsQueryValidator),
+  asyncHandler(ordersStatistics)
+);
 router.get('/:id', authorizeRole(ROLES.ADMIN), validate(mongoIdValidator), asyncHandler(getOrder));
 
 export default router;

--- a/src/modules/orders/services/v1/order.service.js
+++ b/src/modules/orders/services/v1/order.service.js
@@ -344,12 +344,12 @@ export const cancelAnOrder = async (session, orderId, reason, user) => {
 };
 
 export const getOrdersStatistics = async (driverId) => {
-  const aggregateQuery = [];
-  if (driverId) {
-    aggregateQuery.push({ $match: { driverId: new mongoose.Types.ObjectId(driverId) } });
-  }
+  const matchOrder = driverId ? { driverId: new mongoose.Types.ObjectId(driverId) } : {};
 
-  aggregateQuery.push(
+  const matchOffer = driverId ? { driver: new mongoose.Types.ObjectId(driverId) } : {};
+
+  const [orderStats] = await OrderModel.aggregate([
+    { $match: matchOrder },
     {
       $group: {
         _id: null,
@@ -361,18 +361,11 @@ export const getOrdersStatistics = async (driverId) => {
         cancelled: { $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CANCELLED] }, 1, 0] } },
       },
     },
-    { $project: { _id: 0 } }
-  );
+    { $project: { _id: 0 } },
+  ]);
 
-  const statistics = await OrderModel.aggregate(aggregateQuery);
-
-  const offerAggregateQuery = [];
-
-  if (driverId) {
-    offerAggregateQuery.push({ $match: { driver: new mongoose.Types.ObjectId(driverId) } });
-  }
-
-  offerAggregateQuery.push(
+  const [offerStats] = await OfferModel.aggregate([
+    { $match: matchOffer },
     {
       $group: {
         _id: null,
@@ -383,14 +376,23 @@ export const getOrdersStatistics = async (driverId) => {
         expired: { $sum: { $cond: [{ $eq: ['$status', OFFER_STATUS.EXPIRED] }, 1, 0] } },
       },
     },
-    { $project: { _id: 0 } }
-  );
+    { $project: { _id: 0 } },
+  ]);
 
-  const offerStatistics = await OfferModel.aggregate(offerAggregateQuery);
+  return {
+    total: orderStats?.total || 0,
+    created: orderStats?.created || 0,
+    assigned: orderStats?.assigned || 0,
+    pickedUp: orderStats?.pickedUp || 0,
+    delivered: orderStats?.delivered || 0,
+    cancelled: orderStats?.cancelled || 0,
 
-  const result = [...statistics, ...offerStatistics];
-
-  return result;
+    totalOffers: offerStats?.totalOffers || 0,
+    accepted: offerStats?.accepted || 0,
+    rejected: offerStats?.rejected || 0,
+    pending: offerStats?.pending || 0,
+    expired: offerStats?.expired || 0,
+  };
 };
 //#endregion
 

--- a/src/modules/orders/services/v1/order.service.js
+++ b/src/modules/orders/services/v1/order.service.js
@@ -14,11 +14,14 @@ import {
   ORDER_STATUS,
   PAYMENT_STATUS,
   ROLES,
+  OFFER_STATUS,
 } from '#shared/utils/enums.js';
 import { DateHelper } from '#shared/utils/date.helper.js';
 import { calculateItemsTotal } from '#shared/utils/math.helper.js';
 import { orderUpdateQuery } from '#shared/utils/queryBuilder.js';
 import { OrderModel } from '../../models/order.model.js';
+import mongoose from 'mongoose';
+import { OfferModel } from '#modules/offers/index.js';
 
 //#region Admin Services
 
@@ -340,6 +343,55 @@ export const cancelAnOrder = async (session, orderId, reason, user) => {
   return order;
 };
 
+export const getOrdersStatistics = async (driverId) => {
+  const aggregateQuery = [];
+  if (driverId) {
+    aggregateQuery.push({ $match: { driverId: new mongoose.Types.ObjectId(driverId) } });
+  }
+
+  aggregateQuery.push(
+    {
+      $group: {
+        _id: null,
+        total: { $sum: 1 },
+        created: { $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CREATED] }, 1, 0] } },
+        assigned: { $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.ASSIGNED] }, 1, 0] } },
+        pickedUp: { $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.PICKEDUP] }, 1, 0] } },
+        delivered: { $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.DELIVERED] }, 1, 0] } },
+        cancelled: { $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CANCELLED] }, 1, 0] } },
+      },
+    },
+    { $project: { _id: 0 } }
+  );
+
+  const statistics = await OrderModel.aggregate(aggregateQuery);
+
+  const offerAggregateQuery = [];
+
+  if (driverId) {
+    offerAggregateQuery.push({ $match: { driver: new mongoose.Types.ObjectId(driverId) } });
+  }
+
+  offerAggregateQuery.push(
+    {
+      $group: {
+        _id: null,
+        totalOffers: { $sum: 1 },
+        accepted: { $sum: { $cond: [{ $eq: ['$status', OFFER_STATUS.ACCEPTED] }, 1, 0] } },
+        rejected: { $sum: { $cond: [{ $eq: ['$status', OFFER_STATUS.REJECTED] }, 1, 0] } },
+        pending: { $sum: { $cond: [{ $eq: ['$status', OFFER_STATUS.PENDING] }, 1, 0] } },
+        expired: { $sum: { $cond: [{ $eq: ['$status', OFFER_STATUS.EXPIRED] }, 1, 0] } },
+      },
+    },
+    { $project: { _id: 0 } }
+  );
+
+  const offerStatistics = await OfferModel.aggregate(offerAggregateQuery);
+
+  const result = [...statistics, ...offerStatistics];
+
+  return result;
+};
 //#endregion
 
 /** Add drivers info (id, eta, distance ) in related order record */

--- a/src/modules/orders/services/v1/order.service.js
+++ b/src/modules/orders/services/v1/order.service.js
@@ -18,7 +18,7 @@ import {
 } from '#shared/utils/enums.js';
 import { DateHelper } from '#shared/utils/date.helper.js';
 import { calculateItemsTotal } from '#shared/utils/math.helper.js';
-import { orderUpdateQuery } from '#shared/utils/queryBuilder.js';
+import { countByStatus, orderUpdateQuery } from '#shared/utils/queryBuilder.js';
 import { OrderModel } from '../../models/order.model.js';
 import mongoose from 'mongoose';
 import { OfferModel } from '#modules/offers/index.js';
@@ -344,56 +344,65 @@ export const cancelAnOrder = async (session, orderId, reason, user) => {
 };
 
 export const getOrdersStatistics = async (driverId) => {
-  const matchOrder = driverId ? { driverId: new mongoose.Types.ObjectId(driverId) } : {};
+  const driverObjectId = driverId ? new mongoose.Types.ObjectId(driverId) : null;
 
-  const matchOffer = driverId ? { driver: new mongoose.Types.ObjectId(driverId) } : {};
+  const filterOrder = driverObjectId ? { driverId: driverObjectId } : {};
+  const filterOffer = driverObjectId ? { driver: driverObjectId } : {};
 
-  const [orderStats] = await OrderModel.aggregate([
-    { $match: matchOrder },
+  const orderAggregateQuery = [
+    { $match: filterOrder },
     {
       $group: {
         _id: null,
         total: { $sum: 1 },
-        created: { $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CREATED] }, 1, 0] } },
-        assigned: { $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.ASSIGNED] }, 1, 0] } },
-        pickedUp: { $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.PICKEDUP] }, 1, 0] } },
-        delivered: { $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.DELIVERED] }, 1, 0] } },
-        cancelled: { $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CANCELLED] }, 1, 0] } },
+        created: countByStatus(ORDER_STATUS.CREATED),
+        assigned: countByStatus(ORDER_STATUS.ASSIGNED),
+        pickedUp: countByStatus(ORDER_STATUS.PICKEDUP),
+        delivered: countByStatus(ORDER_STATUS.DELIVERED),
+        cancelled: countByStatus(ORDER_STATUS.CANCELLED),
       },
     },
     { $project: { _id: 0 } },
-  ]);
+  ];
 
-  const [offerStats] = await OfferModel.aggregate([
-    { $match: matchOffer },
+  const offerAggregateQuery = [
+    { $match: filterOffer },
     {
       $group: {
         _id: null,
         totalOffers: { $sum: 1 },
-        accepted: { $sum: { $cond: [{ $eq: ['$status', OFFER_STATUS.ACCEPTED] }, 1, 0] } },
-        rejected: { $sum: { $cond: [{ $eq: ['$status', OFFER_STATUS.REJECTED] }, 1, 0] } },
-        pending: { $sum: { $cond: [{ $eq: ['$status', OFFER_STATUS.PENDING] }, 1, 0] } },
-        expired: { $sum: { $cond: [{ $eq: ['$status', OFFER_STATUS.EXPIRED] }, 1, 0] } },
+        accepted: countByStatus(OFFER_STATUS.ACCEPTED),
+        rejected: countByStatus(OFFER_STATUS.REJECTED),
+        pending: countByStatus(OFFER_STATUS.PENDING),
+        expired: countByStatus(OFFER_STATUS.EXPIRED),
       },
     },
     { $project: { _id: 0 } },
+  ];
+
+  const [orderResult, offerResult] = await Promise.all([
+    OrderModel.aggregate(orderAggregateQuery),
+    OfferModel.aggregate(offerAggregateQuery),
   ]);
 
-  return {
-    total: orderStats?.total || 0,
-    created: orderStats?.created || 0,
-    assigned: orderStats?.assigned || 0,
-    pickedUp: orderStats?.pickedUp || 0,
-    delivered: orderStats?.delivered || 0,
-    cancelled: orderStats?.cancelled || 0,
+  const orderStats = orderResult[0] || {};
+  const offerStats = offerResult[0] || {};
 
-    totalOffers: offerStats?.totalOffers || 0,
-    accepted: offerStats?.accepted || 0,
-    rejected: offerStats?.rejected || 0,
-    pending: offerStats?.pending || 0,
-    expired: offerStats?.expired || 0,
+  return {
+    totalOrders: orderStats.total ?? 0,
+    created: orderStats.created ?? 0,
+    assigned: orderStats.assigned ?? 0,
+    pickedUp: orderStats.pickedUp ?? 0,
+    delivered: orderStats.delivered ?? 0,
+    cancelled: orderStats.cancelled ?? 0,
+    totalOffers: offerStats.totalOffers ?? 0,
+    accepted: offerStats.accepted ?? 0,
+    rejected: offerStats.rejected ?? 0,
+    pending: offerStats.pending ?? 0,
+    expired: offerStats.expired ?? 0,
   };
 };
+
 //#endregion
 
 /** Add drivers info (id, eta, distance ) in related order record */

--- a/src/shared/utils/queryBuilder.js
+++ b/src/shared/utils/queryBuilder.js
@@ -142,3 +142,10 @@ export const orderUpdateQuery = (deliveryRequestData, allowedFields) => {
 
   return updateQuery;
 };
+
+// A helper function to return $sum aggregate function based on the order and offer status and reduce the code repetition
+export const countByStatus = (status) => ({
+  $sum: {
+    $cond: [{ $eq: ['$status', status] }, 1, 0],
+  },
+});

--- a/src/tests/config/memoryDB.js
+++ b/src/tests/config/memoryDB.js
@@ -5,6 +5,8 @@ import jwt from 'jsonwebtoken';
 import { UserModel } from '#modules/users/index.js';
 import { DriverModel } from '#modules/drivers/index.js';
 import { randomUUID } from 'crypto';
+import { OrderModel } from '#modules/orders/index.js';
+import { ORDER_STATUS } from '#shared/utils/enums.js';
 let replSet;
 
 export const connectDB = async () => {
@@ -80,4 +82,30 @@ export const createFakeDriver = async (user) => {
   });
 
   return newDriver;
+};
+
+export const createFakeOrder = async (overrides = {}) => {
+  return await OrderModel.create({
+    type: 'parcel',
+    serviceType: 'immediate',
+    status: ORDER_STATUS.CREATED,
+
+    sender: { name: 'Test Sender', phone: '0700000000' },
+    receiver: {
+      name: 'Test Receiver',
+      phone: '0700000000',
+      address: 'Herat',
+    },
+
+    pickupLocation: { type: 'Point', coordinates: [62.2, 34.35] },
+    dropoffLocation: { type: 'Point', coordinates: [62.2, 34.35] },
+
+    paymentType: 'COD',
+    amountToCollect: 100,
+    deliveryPrice: { total: 20 },
+
+    createdAt: new Date(),
+
+    ...overrides,
+  });
 };

--- a/src/tests/integration/modules/orders/v1/order.routes.test.js
+++ b/src/tests/integration/modules/orders/v1/order.routes.test.js
@@ -1067,7 +1067,7 @@ describe('Order API v1 Integration', () => {
     });
   });
 
-  describe('Integration - Orders Statistics', () => {
+  describe('GET /api/orders/statistics', () => {
     beforeEach(async () => {
       vi.clearAllMocks();
       await clearDB();
@@ -1153,7 +1153,23 @@ describe('Order API v1 Integration', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
-      expect(res.body.data).toEqual({});
+
+      expect(res.body.data).toEqual(
+        expect.objectContaining({
+          total: 0,
+          created: 0,
+          assigned: 0,
+          pickedUp: 0,
+          delivered: 0,
+          cancelled: 0,
+
+          totalOffers: 0,
+          accepted: 0,
+          rejected: 0,
+          pending: 0,
+          expired: 0,
+        })
+      );
     });
 
     it('should filter statistics using driverId query (admin)', async () => {

--- a/src/tests/integration/modules/orders/v1/order.routes.test.js
+++ b/src/tests/integration/modules/orders/v1/order.routes.test.js
@@ -1101,7 +1101,7 @@ describe('Order API v1 Integration', () => {
 
       expect(res.body.data).toEqual(
         expect.objectContaining({
-          total: 3,
+          totalOrders: 3,
           created: 1,
           delivered: 1,
           cancelled: 1,
@@ -1139,7 +1139,7 @@ describe('Order API v1 Integration', () => {
 
       expect(res.body.data).toEqual(
         expect.objectContaining({
-          total: 2,
+          totalOrders: 2,
           created: 1,
           delivered: 1,
         })
@@ -1156,7 +1156,7 @@ describe('Order API v1 Integration', () => {
 
       expect(res.body.data).toEqual(
         expect.objectContaining({
-          total: 0,
+          totalOrders: 0,
           created: 0,
           assigned: 0,
           pickedUp: 0,
@@ -1198,7 +1198,7 @@ describe('Order API v1 Integration', () => {
       expect(res.body.success).toBe(true);
       expect(res.body.data).toEqual(
         expect.objectContaining({
-          total: 2,
+          totalOrders: 2,
           created: 1,
           delivered: 1,
         })

--- a/src/tests/integration/modules/orders/v1/order.routes.test.js
+++ b/src/tests/integration/modules/orders/v1/order.routes.test.js
@@ -7,6 +7,7 @@ import {
   clearDB,
   createFakeUserWithToken,
   createFakeDriver,
+  createFakeOrder,
 } from '../../../../config/memoryDB.js';
 import { OrderModel } from '#modules/orders/models/order.model.js';
 import { getWithAuth, postWithAuth } from '#tests/utils/testHelpers.js';
@@ -1063,6 +1064,129 @@ describe('Order API v1 Integration', () => {
       expect(res.body.success).toBe(true);
       expect(res.body.data.type).toBe('parcel');
       expect(res.body.data.serviceType).toBe('immediate');
+    });
+  });
+
+  describe('Integration - Orders Statistics', () => {
+    beforeEach(async () => {
+      vi.clearAllMocks();
+      await clearDB();
+    });
+
+    it('should return global statistics when request comes from admin', async () => {
+      const admin = await createFakeUserWithToken('admin');
+
+      const driverUser = await createFakeUserWithToken('driver');
+      const driver = await createFakeDriver(driverUser.testUserId);
+
+      await createFakeOrder({
+        driverId: driver._id,
+        status: ORDER_STATUS.CREATED,
+      });
+
+      await createFakeOrder({
+        driverId: driver._id,
+        status: ORDER_STATUS.DELIVERED,
+      });
+
+      await createFakeOrder({
+        driverId: null,
+        status: ORDER_STATUS.CANCELLED,
+      });
+
+      const res = await getWithAuth(app, `${baseURL}/statistics`, admin.token);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      expect(res.body.data).toEqual(
+        expect.objectContaining({
+          total: 3,
+          created: 1,
+          delivered: 1,
+          cancelled: 1,
+        })
+      );
+    });
+
+    it('should return only driver statistics when request comes from driver', async () => {
+      const user = await createFakeUserWithToken('driver');
+      const driver = await createFakeDriver(user.testUserId);
+
+      await createFakeOrder({
+        driverId: driver._id,
+        status: ORDER_STATUS.CREATED,
+      });
+
+      await createFakeOrder({
+        driverId: driver._id,
+        status: ORDER_STATUS.DELIVERED,
+      });
+
+      // other driver (must NOT be included)
+      const otherUser = await createFakeUserWithToken('driver');
+      const otherDriver = await createFakeDriver(otherUser.testUserId);
+
+      await createFakeOrder({
+        driverId: otherDriver._id,
+        status: ORDER_STATUS.CREATED,
+      });
+
+      const res = await getWithAuth(app, `${baseURL}/statistics`, user.token);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      expect(res.body.data).toEqual(
+        expect.objectContaining({
+          total: 2,
+          created: 1,
+          delivered: 1,
+        })
+      );
+    });
+
+    it('should return empty object when no orders exist', async () => {
+      const admin = await createFakeUserWithToken('admin');
+
+      const res = await getWithAuth(app, `${baseURL}/statistics`, admin.token);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual({});
+    });
+
+    it('should filter statistics using driverId query (admin)', async () => {
+      const admin = await createFakeUserWithToken('admin');
+
+      const user = await createFakeUserWithToken('driver');
+      const driver = await createFakeDriver(user.testUserId);
+
+      await createFakeOrder({
+        driverId: driver._id,
+        status: ORDER_STATUS.CREATED,
+      });
+
+      await createFakeOrder({
+        driverId: driver._id,
+        status: ORDER_STATUS.DELIVERED,
+      });
+
+      const res = await getWithAuth(
+        app,
+        `${baseURL}/statistics?driverId=${driver._id}`,
+        admin.token
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual(
+        expect.objectContaining({
+          total: 2,
+          created: 1,
+          delivered: 1,
+        })
+      );
     });
   });
 });

--- a/src/tests/unit/modules/ordres/v1/order.controller.test.js
+++ b/src/tests/unit/modules/ordres/v1/order.controller.test.js
@@ -16,8 +16,12 @@ import {
   getAllOrders,
   getOrder,
   getOrderById,
+  ordersStatistics,
+  getOrdersStatistics,
 } from '#modules/orders/index.js';
 import { AppError, notFound } from '#shared/errors/error.js';
+import { ROLES } from '#shared/utils/enums.js';
+import { fetchDriverByUserId } from '#modules/drivers/index.js';
 
 // Mock the service
 vi.mock('#modules/orders/services/v1/order.service.js', () => ({
@@ -29,6 +33,10 @@ vi.mock('#modules/orders/services/v1/order.service.js', () => ({
   cancelOrderWithTransaction: vi.fn(),
   getAllOrders: vi.fn(),
   getOrderById: vi.fn(),
+  getOrdersStatistics: vi.fn(),
+}));
+vi.mock('#modules/drivers/services/v1/driver.service.js', () => ({
+  fetchDriverByUserId: vi.fn(),
 }));
 
 describe('Controller Order - create order', () => {
@@ -698,5 +706,102 @@ describe('Controller Order - getOrder (By Id)', () => {
       success: true,
       data: mockOrder,
     });
+  });
+});
+
+describe('Controller Order - ordersStatistics', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    req = {
+      user: { _id: 'user123', role: ROLES.ADMIN },
+      query: {},
+    };
+
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+  });
+
+  it('should throw unauthorized if user is missing', async () => {
+    req.user = null;
+
+    await expect(ordersStatistics(req, res)).rejects.toThrow(AppError);
+  });
+
+  it('should return statistics for admin (no driverId)', async () => {
+    const mockStats = {
+      total: 10,
+      created: 2,
+      assigned: 3,
+      pickedUp: 2,
+      delivered: 2,
+      cancelled: 1,
+    };
+
+    getOrdersStatistics.mockResolvedValue(mockStats);
+
+    await ordersStatistics(req, res);
+
+    expect(getOrdersStatistics).toHaveBeenCalledWith(null);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: mockStats,
+    });
+  });
+
+  it('should use driverId from query for admin', async () => {
+    req.query.driverId = 'driver123';
+
+    const mockStats = { total: 5 };
+    getOrdersStatistics.mockResolvedValue(mockStats);
+
+    await ordersStatistics(req, res);
+
+    expect(getOrdersStatistics).toHaveBeenCalledWith('driver123');
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: mockStats,
+    });
+  });
+
+  it('should use driverId from logged-in driver user', async () => {
+    req.user.role = ROLES.DRIVER;
+
+    const mockDriver = { _id: 'driverId123' };
+    fetchDriverByUserId.mockResolvedValue(mockDriver);
+
+    const mockStats = { total: 7 };
+    getOrdersStatistics.mockResolvedValue(mockStats);
+
+    await ordersStatistics(req, res);
+
+    expect(fetchDriverByUserId).toHaveBeenCalledWith('user123');
+    expect(getOrdersStatistics).toHaveBeenCalledWith('driverId123');
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: mockStats,
+    });
+  });
+
+  it('should throw notFound if driver does not exist', async () => {
+    req.user.role = ROLES.DRIVER;
+
+    fetchDriverByUserId.mockResolvedValue(null);
+
+    await expect(ordersStatistics(req, res)).rejects.toThrow(AppError);
+
+    expect(fetchDriverByUserId).toHaveBeenCalledWith('user123');
+    expect(getOrdersStatistics).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/unit/modules/ordres/v1/order.service.test.js
+++ b/src/tests/unit/modules/ordres/v1/order.service.test.js
@@ -31,6 +31,7 @@ import {
 import { DateHelper } from '#shared/utils/date.helper.js';
 import { DtoService } from '#shared/utils/dtoService.js';
 import { eventBus } from '#shared/event-bus/eventBus.js';
+import { OfferModel } from '#modules/offers/index.js';
 
 vi.mock('#modules/orders/models/order.model.js', () => ({
   OrderModel: {
@@ -39,6 +40,11 @@ vi.mock('#modules/orders/models/order.model.js', () => ({
     findByIdAndUpdate: vi.fn(),
     find: vi.fn(),
     countDocuments: vi.fn(),
+    aggregate: vi.fn(),
+  },
+}));
+vi.mock('#modules/offers/models/offer.model.js', () => ({
+  OfferModel: {
     aggregate: vi.fn(),
   },
 }));
@@ -1255,7 +1261,7 @@ describe('getAllOrders', () => {
   });
 });
 
-describe('getOrdersStatistics', () => {
+describe.only('getOrdersStatistics', () => {
   it('should return global orders statistics (no driver filter)', async () => {
     const mockAggregateResult = [
       {
@@ -1268,38 +1274,41 @@ describe('getOrdersStatistics', () => {
       },
     ];
 
+    const mockOfferAggregateResult = [
+      {
+        totalOffers: 8,
+        accepted: 2,
+        rejected: 2,
+        pending: 2,
+        expired: 2,
+      },
+    ];
+
     OrderModel.aggregate.mockResolvedValue(mockAggregateResult);
+    OfferModel.aggregate.mockResolvedValue(mockOfferAggregateResult);
 
     const result = await getOrdersStatistics();
 
-    expect(OrderModel.aggregate).toHaveBeenCalledWith([
-      {
-        $group: {
-          _id: null,
-          total: { $sum: 1 },
-          created: {
-            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CREATED] }, 1, 0] },
-          },
-          assigned: {
-            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.ASSIGNED] }, 1, 0] },
-          },
-          pickedUp: {
-            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.PICKEDUP] }, 1, 0] },
-          },
-          delivered: {
-            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.DELIVERED] }, 1, 0] },
-          },
-          cancelled: {
-            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CANCELLED] }, 1, 0] },
-          },
-        },
-      },
-      { $project: { _id: 0 } },
-    ]);
+    expect(OrderModel.aggregate).toHaveBeenCalled();
+    expect(OfferModel.aggregate).toHaveBeenCalled();
 
-    expect(result).toEqual(mockAggregateResult[0]);
+    expect(result).toEqual(
+      expect.objectContaining({
+        total: 10,
+        created: 2,
+        assigned: 3,
+        pickedUp: 2,
+        delivered: 2,
+        cancelled: 1,
+
+        totalOffers: 8,
+        accepted: 2,
+        rejected: 2,
+        pending: 2,
+        expired: 2,
+      })
+    );
   });
-
   it('should return driver-specific orders statistics', async () => {
     const driverId = '69e8bc01cd541e0923f901f8';
 
@@ -1315,43 +1324,47 @@ describe('getOrdersStatistics', () => {
     ];
 
     OrderModel.aggregate.mockResolvedValue(mockAggregateResult);
+    OfferModel.aggregate.mockResolvedValue([]);
 
     const result = await getOrdersStatistics(driverId);
 
     expect(OrderModel.aggregate).toHaveBeenCalledWith([
       { $match: { driverId: new mongoose.Types.ObjectId(driverId) } },
-      {
-        $group: {
-          _id: null,
-          total: { $sum: 1 },
-          created: {
-            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CREATED] }, 1, 0] },
-          },
-          assigned: {
-            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.ASSIGNED] }, 1, 0] },
-          },
-          pickedUp: {
-            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.PICKEDUP] }, 1, 0] },
-          },
-          delivered: {
-            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.DELIVERED] }, 1, 0] },
-          },
-          cancelled: {
-            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CANCELLED] }, 1, 0] },
-          },
-        },
-      },
+      expect.any(Object), // group stage
       { $project: { _id: 0 } },
     ]);
 
-    expect(result).toEqual(mockAggregateResult[0]);
+    expect(result).toEqual(
+      expect.objectContaining({
+        total: 5,
+        created: 1,
+        assigned: 1,
+        pickedUp: 1,
+        delivered: 1,
+        cancelled: 1,
+      })
+    );
   });
-
   it('should return empty object when no statistics found', async () => {
     OrderModel.aggregate.mockResolvedValue([]);
+    OfferModel.aggregate.mockResolvedValue([]);
 
     const result = await getOrdersStatistics();
 
-    expect(result).toEqual({});
+    expect(result).toEqual(
+      expect.objectContaining({
+        total: 0,
+        created: 0,
+        assigned: 0,
+        pickedUp: 0,
+        delivered: 0,
+        cancelled: 0,
+        totalOffers: 0,
+        accepted: 0,
+        rejected: 0,
+        pending: 0,
+        expired: 0,
+      })
+    );
   });
 });

--- a/src/tests/unit/modules/ordres/v1/order.service.test.js
+++ b/src/tests/unit/modules/ordres/v1/order.service.test.js
@@ -15,6 +15,7 @@ import {
   OrderModel,
   pickupOrderWithTransaction,
   getAllOrders,
+  getOrdersStatistics,
 } from '#modules/orders/index.js';
 import mongoose from 'mongoose';
 import { ERROR_CODES } from '#shared/errors/customCodes.js';
@@ -38,6 +39,7 @@ vi.mock('#modules/orders/models/order.model.js', () => ({
     findByIdAndUpdate: vi.fn(),
     find: vi.fn(),
     countDocuments: vi.fn(),
+    aggregate: vi.fn(),
   },
 }));
 
@@ -1250,5 +1252,106 @@ describe('getAllOrders', () => {
       totalOrders: 14,
       totalPage: 3,
     });
+  });
+});
+
+describe('getOrdersStatistics', () => {
+  it('should return global orders statistics (no driver filter)', async () => {
+    const mockAggregateResult = [
+      {
+        total: 10,
+        created: 2,
+        assigned: 3,
+        pickedUp: 2,
+        delivered: 2,
+        cancelled: 1,
+      },
+    ];
+
+    OrderModel.aggregate.mockResolvedValue(mockAggregateResult);
+
+    const result = await getOrdersStatistics();
+
+    expect(OrderModel.aggregate).toHaveBeenCalledWith([
+      {
+        $group: {
+          _id: null,
+          total: { $sum: 1 },
+          created: {
+            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CREATED] }, 1, 0] },
+          },
+          assigned: {
+            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.ASSIGNED] }, 1, 0] },
+          },
+          pickedUp: {
+            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.PICKEDUP] }, 1, 0] },
+          },
+          delivered: {
+            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.DELIVERED] }, 1, 0] },
+          },
+          cancelled: {
+            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CANCELLED] }, 1, 0] },
+          },
+        },
+      },
+      { $project: { _id: 0 } },
+    ]);
+
+    expect(result).toEqual(mockAggregateResult[0]);
+  });
+
+  it('should return driver-specific orders statistics', async () => {
+    const driverId = '69e8bc01cd541e0923f901f8';
+
+    const mockAggregateResult = [
+      {
+        total: 5,
+        created: 1,
+        assigned: 1,
+        pickedUp: 1,
+        delivered: 1,
+        cancelled: 1,
+      },
+    ];
+
+    OrderModel.aggregate.mockResolvedValue(mockAggregateResult);
+
+    const result = await getOrdersStatistics(driverId);
+
+    expect(OrderModel.aggregate).toHaveBeenCalledWith([
+      { $match: { driverId: new mongoose.Types.ObjectId(driverId) } },
+      {
+        $group: {
+          _id: null,
+          total: { $sum: 1 },
+          created: {
+            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CREATED] }, 1, 0] },
+          },
+          assigned: {
+            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.ASSIGNED] }, 1, 0] },
+          },
+          pickedUp: {
+            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.PICKEDUP] }, 1, 0] },
+          },
+          delivered: {
+            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.DELIVERED] }, 1, 0] },
+          },
+          cancelled: {
+            $sum: { $cond: [{ $eq: ['$status', ORDER_STATUS.CANCELLED] }, 1, 0] },
+          },
+        },
+      },
+      { $project: { _id: 0 } },
+    ]);
+
+    expect(result).toEqual(mockAggregateResult[0]);
+  });
+
+  it('should return empty object when no statistics found', async () => {
+    OrderModel.aggregate.mockResolvedValue([]);
+
+    const result = await getOrdersStatistics();
+
+    expect(result).toEqual({});
   });
 });

--- a/src/tests/unit/modules/ordres/v1/order.service.test.js
+++ b/src/tests/unit/modules/ordres/v1/order.service.test.js
@@ -68,6 +68,7 @@ vi.mock('#shared/utils/math.helper.js', () => ({
 vi.mock('#shared/utils/queryBuilder.js', () => ({
   orderUpdateQuery: vi.fn(),
   driverQueryBuilder: vi.fn(),
+  countByStatus: vi.fn(() => ({ $sum: 1 })),
 }));
 
 vi.mock('#shared/utils/date.helper.js', () => ({
@@ -1261,7 +1262,7 @@ describe('getAllOrders', () => {
   });
 });
 
-describe.only('getOrdersStatistics', () => {
+describe('getOrdersStatistics', () => {
   it('should return global orders statistics (no driver filter)', async () => {
     const mockAggregateResult = [
       {
@@ -1294,7 +1295,7 @@ describe.only('getOrdersStatistics', () => {
 
     expect(result).toEqual(
       expect.objectContaining({
-        total: 10,
+        totalOrders: 10,
         created: 2,
         assigned: 3,
         pickedUp: 2,
@@ -1336,7 +1337,7 @@ describe.only('getOrdersStatistics', () => {
 
     expect(result).toEqual(
       expect.objectContaining({
-        total: 5,
+        totalOrders: 5,
         created: 1,
         assigned: 1,
         pickedUp: 1,
@@ -1353,7 +1354,7 @@ describe.only('getOrdersStatistics', () => {
 
     expect(result).toEqual(
       expect.objectContaining({
-        total: 0,
+        totalOrders: 0,
         created: 0,
         assigned: 0,
         pickedUp: 0,

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -18,5 +18,6 @@ export default defineConfig({
     testTimeout: 30000,
     hookTimeout: 30000,
     teardownTimeout: 30000,
+    setupFiles: ['./vitest.setup.js'], // This config add the .env in our tests. In future we can add a .env for our tests if needed.
   },
 });

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,3 @@
+import dotenv from 'dotenv';
+
+dotenv.config();


### PR DESCRIPTION
I implemented the functionality that admin can retrieve all orders statistics, and also a driver can retrieve his/her own orders statistics.

### CHANGES INCLUDES: 
- [x] `getOrders` route return orders data based on Role(admin or driver)
- [x] `/statistics` route  return the order statistics based on role(admin or driver)
- [x] Driver can only access his/her own order statistics
- [x] Admin can access all orders statistics
- [x] Admin ca access order statistics of a specifid driver by providing the `driverId` in request query parameter.
- [x] Add validator for `driverId` in query parameter.
- [x] Add integration tests
- [x] Add unit tests     
- [x] Inject the `.env` in test environment
- [ ] Peer Review
- [x] Reporter Review
- [x] Automation Tests


## Closes
Closes #95    