### PR TITLE
SCRUM-22: Socket Initialization Bug

### DIFF
--- a/src/shared/middleware/authMiddleware.js
+++ b/src/shared/middleware/authMiddleware.js
@@ -13,7 +13,7 @@ export const authMiddleware = asyncHandler(async (req, res, next) => {
 
   const token = authHeader.split(' ')[1];
   const decoded = verifyJWT(token);
-  if (!decoded.id) {
+  if (!decoded?.id) {
     throw new AppError('Unauthorized: Invalid token payload', 401, ERROR_CODES.INVALID_JWT);
   }
 

--- a/src/shared/utils/jwt.js
+++ b/src/shared/utils/jwt.js
@@ -13,7 +13,11 @@ export const cookieOptions = {
 };
 
 export const verifyJWT = (token) => {
-  return jwt.verify(token, process.env.JWT_SECRET);
+  try {
+    return jwt.verify(token, process.env.JWT_SECRET);
+  } catch {
+    return null;
+  }
 };
 
 export const generateAccessToken = (user) => {


### PR DESCRIPTION
When an invalid token send to backend to initialize a web socket connection, the backend crashed. I fixed this problem by adding a `try-catch` block inside `verifyJWT` function.

### Changes Includes
- [x] Add try-catch block inside the `verifyJWT` function.
- [x] Add optional chaining operator in `authMiddleware`
- [ ] Peer Review
- [x] Reporter Review
- [x] Automation Tests

### Closes
 closes SCRUM-22