### PR TITLE
SCRUM-24: Add Local and Production Frontend URLs in Cors Origin

### DIFF
--- a/src/config/cors.js
+++ b/src/config/cors.js
@@ -1,4 +1,4 @@
-const origins = process.env.FRONTEND_URL;
+const origins = [process.env.FRONTEND_URL, 'http://localhost:5173']; // Allow local and production frontend origins
 
 export const corsOptions = {
   origin: origins,


### PR DESCRIPTION
Our previous `cors` options only support local or production frontend urls, not both at the same time, which cause problem working with local frontend and online backend or vise versa. Now the `cors` options support both urls at the same time.

### Closes
Close SRUM-24