### PR TITLE
SCRUM-25 remove FCM token on logout

### DIFF
--- a/src/modules/users/controllers/v1/auth.controller.js
+++ b/src/modules/users/controllers/v1/auth.controller.js
@@ -94,11 +94,12 @@ export const changePassword = async (req, res) => {
 export const logout = async (req, res) => {
   const refreshToken = req.cookies?.refreshToken;
   const deviceId = req.cookies?.deviceId;
+  const deviceIdFornt = req.body.deviceId;
 
   if (!refreshToken || !deviceId)
     throw new AppError('Invalid session data for logout', 401, ERROR_CODES.LOGOUT_INVALID_SESSION);
 
-  await logoutUser({ refreshToken, deviceId });
+  await logoutUser({ refreshToken, deviceId, deviceIdFornt });
 
   res.clearCookie('refreshToken', cookieOptions);
   res.clearCookie('deviceId', cookieOptions);

--- a/src/modules/users/controllers/v1/auth.controller.js
+++ b/src/modules/users/controllers/v1/auth.controller.js
@@ -94,12 +94,12 @@ export const changePassword = async (req, res) => {
 export const logout = async (req, res) => {
   const refreshToken = req.cookies?.refreshToken;
   const deviceId = req.cookies?.deviceId;
-  const deviceIdFornt = req.body.deviceId;
+  const frontDeviceId = req.body.deviceId;
 
   if (!refreshToken || !deviceId)
     throw new AppError('Invalid session data for logout', 401, ERROR_CODES.LOGOUT_INVALID_SESSION);
 
-  await logoutUser({ refreshToken, deviceId, deviceIdFornt });
+  await logoutUser({ refreshToken, deviceId, frontDeviceId });
 
   res.clearCookie('refreshToken', cookieOptions);
   res.clearCookie('deviceId', cookieOptions);

--- a/src/modules/users/controllers/v1/auth.controller.js
+++ b/src/modules/users/controllers/v1/auth.controller.js
@@ -94,7 +94,7 @@ export const changePassword = async (req, res) => {
 export const logout = async (req, res) => {
   const refreshToken = req.cookies?.refreshToken;
   const deviceId = req.cookies?.deviceId;
-  const frontDeviceId = req.body.deviceId;
+  const frontDeviceId = req.body?.deviceId;
 
   if (!refreshToken || !deviceId)
     throw new AppError('Invalid session data for logout', 401, ERROR_CODES.LOGOUT_INVALID_SESSION);

--- a/src/modules/users/services/v1/auth.service.js
+++ b/src/modules/users/services/v1/auth.service.js
@@ -13,7 +13,7 @@ import { AppError, notFound, unauthorized } from '#shared/errors/error.js';
 import { ERROR_CODES } from '#shared/errors/customCodes.js';
 import { agenda } from '#config/agenda.js';
 import { verifyGoogleToken } from '#shared/utils/googleOAuth.js';
-import { removeFCMTokenForDeviceId } from './user.service.js';
+import { removeFCMTokenByDeviceId } from './user.service.js';
 
 
 //!  Helper Functions
@@ -249,7 +249,6 @@ export const loginService = async ({ email, password }, deviceId) => {
       setDefaultsOnInsert: true,
     }
   );
-  console.log('user logged in!')
   return {
     id: user._id,
     email: user.email,
@@ -355,21 +354,21 @@ export const changePasswordService = async (userId, { currentPassword, newPasswo
   await RefreshTokenModel.deleteMany({ user: user._id });
 };
 
-export const logoutUser = async ({ refreshToken, deviceId, deviceIdFornt }) => {
+export const logoutUser = async ({ refreshToken, deviceId, frontDeviceId }) => {
   const hashedToken = hashToken(refreshToken);
 
-  const tokenDoc = await RefreshTokenModel.findOne({
+  const tokenDocument = await RefreshTokenModel.findOne({
     token: hashedToken,
     deviceId,
   }).populate('user');
 
-  if (!tokenDoc) return;
+  if (!tokenDocument) return;
 
-  const userId = tokenDoc.user._id;
+  const userId = tokenDocument.user._id;
 
-  await RefreshTokenModel.deleteOne({ _id: tokenDoc._id });
+  await RefreshTokenModel.deleteOne({ _id: tokenDocument._id });
 
-  if (deviceIdFornt) {
-    await removeFCMTokenForDeviceId(userId, deviceIdFornt);
+  if (frontDeviceId) {
+    await removeFCMTokenByDeviceId(userId, frontDeviceId);
   }  
 };

--- a/src/modules/users/services/v1/auth.service.js
+++ b/src/modules/users/services/v1/auth.service.js
@@ -13,6 +13,7 @@ import { AppError, notFound, unauthorized } from '#shared/errors/error.js';
 import { ERROR_CODES } from '#shared/errors/customCodes.js';
 import { agenda } from '#config/agenda.js';
 import { verifyGoogleToken } from '#shared/utils/googleOAuth.js';
+import { removeFCMTokenForDevice } from './user.service.js';
 
 //!  Helper Functions
 
@@ -247,7 +248,7 @@ export const loginService = async ({ email, password }, deviceId) => {
       setDefaultsOnInsert: true,
     }
   );
-
+  console.log('user logged in!')
   return {
     id: user._id,
     email: user.email,
@@ -356,5 +357,18 @@ export const changePasswordService = async (userId, { currentPassword, newPasswo
 export const logoutUser = async ({ refreshToken, deviceId }) => {
   const hashedToken = hashToken(refreshToken);
 
-  await RefreshTokenModel.deleteOne({ token: hashedToken, deviceId });
+  const tokenDoc = await RefreshTokenModel.findOne({
+    token: hashedToken,
+    deviceId,
+  }).populate('user');
+
+  if (!tokenDoc) return;
+
+  const userId = tokenDoc.user._id;
+
+  await RefreshTokenModel.deleteOne({ _id: tokenDoc._id });
+
+  if (deviceId) {
+    await removeFCMTokenForDevice(userId, deviceId);
+  }
 };

--- a/src/modules/users/services/v1/auth.service.js
+++ b/src/modules/users/services/v1/auth.service.js
@@ -13,7 +13,8 @@ import { AppError, notFound, unauthorized } from '#shared/errors/error.js';
 import { ERROR_CODES } from '#shared/errors/customCodes.js';
 import { agenda } from '#config/agenda.js';
 import { verifyGoogleToken } from '#shared/utils/googleOAuth.js';
-import { removeFCMTokenForDevice } from './user.service.js';
+import { removeFCMTokenForDeviceId } from './user.service.js';
+
 
 //!  Helper Functions
 
@@ -354,7 +355,7 @@ export const changePasswordService = async (userId, { currentPassword, newPasswo
   await RefreshTokenModel.deleteMany({ user: user._id });
 };
 
-export const logoutUser = async ({ refreshToken, deviceId }) => {
+export const logoutUser = async ({ refreshToken, deviceId, deviceIdFornt }) => {
   const hashedToken = hashToken(refreshToken);
 
   const tokenDoc = await RefreshTokenModel.findOne({
@@ -368,7 +369,7 @@ export const logoutUser = async ({ refreshToken, deviceId }) => {
 
   await RefreshTokenModel.deleteOne({ _id: tokenDoc._id });
 
-  if (deviceId) {
-    await removeFCMTokenForDevice(userId, deviceId);
-  }
+  if (deviceIdFornt) {
+    await removeFCMTokenForDeviceId(userId, deviceIdFornt);
+  }  
 };

--- a/src/modules/users/services/v1/user.service.js
+++ b/src/modules/users/services/v1/user.service.js
@@ -85,7 +85,7 @@ export const removeFCMToken = async (userId, fcmToken) => {
 
   
 export const removeFCMTokenByDeviceId = async (userId, deviceId) => {
-  const updatedDevices = await UserModel.findOneAndUpdate(
+  await UserModel.findOneAndUpdate(
     {
       _id: userId,
       'devices.deviceId': deviceId,

--- a/src/modules/users/services/v1/user.service.js
+++ b/src/modules/users/services/v1/user.service.js
@@ -84,7 +84,7 @@ export const removeFCMToken = async (userId, fcmToken) => {
 };
 
   
-export const removeFCMTokenForDeviceId = async (userId, deviceId) => {
+export const removeFCMTokenByDeviceId = async (userId, deviceId) => {
   const updatedDevices = await UserModel.findOneAndUpdate(
     {
       _id: userId,
@@ -94,9 +94,6 @@ export const removeFCMTokenForDeviceId = async (userId, deviceId) => {
       $set: {
         'devices.$.fcmToken': null,
       },
-    },
-    { new: true }
+    }
   );
-
-  return updatedDevices;
 };

--- a/src/modules/users/services/v1/user.service.js
+++ b/src/modules/users/services/v1/user.service.js
@@ -80,5 +80,20 @@ export const removeFCMToken = async (userId, fcmToken) => {
         fcmToken,
       },
     },
-  });
-};
+  })};
+
+  
+export const removeFCMTokenForDevice = async (userId, deviceId) => {
+  return await UserModel.findOneAndUpdate(
+    {
+      _id: userId,
+      'devices.deviceId': deviceId,
+    },
+    {
+      $set: {
+        'devices.$.fcmToken': null,
+      },
+    },
+    { new: true }
+  )
+}

--- a/src/modules/users/services/v1/user.service.js
+++ b/src/modules/users/services/v1/user.service.js
@@ -80,11 +80,12 @@ export const removeFCMToken = async (userId, fcmToken) => {
         fcmToken,
       },
     },
-  })};
+  })
+};
 
   
-export const removeFCMTokenForDevice = async (userId, deviceId) => {
-  return await UserModel.findOneAndUpdate(
+export const removeFCMTokenForDeviceId = async (userId, deviceId) => {
+  const updatedDevices = await UserModel.findOneAndUpdate(
     {
       _id: userId,
       'devices.deviceId': deviceId,
@@ -95,5 +96,7 @@ export const removeFCMTokenForDevice = async (userId, deviceId) => {
       },
     },
     { new: true }
-  )
-}
+  );
+
+  return updatedDevices;
+};

--- a/src/tests/unit/modules/users/v1/logout.controller.test.js
+++ b/src/tests/unit/modules/users/v1/logout.controller.test.js
@@ -15,7 +15,7 @@ describe('Auth controller - logout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    req = { cookies: {} };
+    req = { cookies: {}, body: {},};
 
     res = {
       clearCookie: vi.fn(),


### PR DESCRIPTION
## Summary 

- In this pull request I tried to implement a logic to remove the `fcToken` of related device as the user logs out, ensuring that they don't receive a further push notifications from firebase services.

### Changes Made:

- Received the `deviceIdFornt` from the `req.body` of logout request sent to the backend by frontend and passed it to the `logoutUser` function for further use.
- Created a new function called `removeFCMTokenForDeviceId` in the user service file, the function makes the `fcmToken` value as null based on the deviceId that is sent through logout request.
- Implemented the `removeFCMTokenForDeviceId` function in the `logoutUser` so that the `fcmToken` is removed successfully based on the `deviceId`.

**Reviewers**:

- [x] Mentor
- [x] Peers

**Closes**
Closes #115