### PR TITLE
Updated the verification email destination to the real user's inbox FMH

### DIFF
--- a/.env
+++ b/.env
@@ -6,10 +6,11 @@ JWT_EXPIRES_IN=30d
 GEOAPIFY_KEY = 4c896d28e9d94d2ca22002495421793e
 GEOAPIFY_URL = https://api.geoapify.com/v1/
 GOOGLE_CLIENT_ID=815631933051-binek52kicum712b57t4724jja40fa5i.apps.googleusercontent.com
-EMAIL_HOST=sandbox.smtp.mailtrap.io
-EMAIL_PORT=2525
-EMAIL_USER=2678568252d3ac
-EMAIL_PASSWORD=7e2fd379c83bdb
+EMAIL_HOST=smtp-relay.brevo.com
+EMAIL_PORT=587 
+EMAIL_USER=ab2426001@smtp-brevo.com
+EMAIL_PASSWORD=
+EMAIL_FROM="Mizban Delivery System <deliverysystem971@gmail.com>"
 FRONTEND_URL=http://localhost:5173
 Offer_Expires_In_Seconds = 30
 # SERVICE_ACCOUNT_KEY_CREDINTINAL_DATA

--- a/src/shared/utils/email.js
+++ b/src/shared/utils/email.js
@@ -298,12 +298,21 @@ export const sendEmail = async ({
   const transporter = nodemailer.createTransport({
     host: process.env.EMAIL_HOST,
     port: process.env.EMAIL_PORT,
+    secure: false,
     auth: {
-      user: process.env.EMAIL_USER,
-      pass: process.env.EMAIL_PASSWORD,
+      user: process.env.EMAIL_USER.trim(),
+      pass: process.env.EMAIL_PASSWORD.trim(),
     },
   });
+  
+  try {
+    await transporter.verify();
+    console.log("SMTP connection is verified");
+  } catch (err) {
+    console.error("the SMTP verification error", err);
+  }
 
+  
   const html =
     template === 'verify_email'
       ? generateVerifyEmailTemplate(username, verifyUrl)
@@ -315,6 +324,5 @@ export const sendEmail = async ({
     subject,
     html,
   };
-
   await transporter.sendMail(emailOption);
 };

--- a/src/shared/utils/email.js
+++ b/src/shared/utils/email.js
@@ -304,15 +304,14 @@ export const sendEmail = async ({
       pass: process.env.EMAIL_PASSWORD.trim(),
     },
   });
-  
+
   try {
     await transporter.verify();
-    console.log("SMTP connection is verified");
+    console.log('SMTP connection is verified');
   } catch (err) {
-    console.error("the SMTP verification error", err);
+    console.error('the SMTP verification error', err);
   }
 
-  
   const html =
     template === 'verify_email'
       ? generateVerifyEmailTemplate(username, verifyUrl)


### PR DESCRIPTION
## Summary

- In this branch I tried to use from brevo.com services as a service that manages the customers communications, instead of using Mailtrap sandbox. In order to send real emails as designed in the system to real user's inbox. 
- I created a free brevo account using the delivery shared account, and connected it to the system using main credintials.
- I tested the email delivery and ensured that the emails are send to the correct destination.
- I also generated a SMTP key that would expire after 90 days of inactivity.

**Reviewers**
- [x] Mentor
- [x] Peer

**Note** Since GitHub restricting rules did not allow to push the value of `EMAIL_PASSWORD`, I used to cut that from the `.env` file, I can send that easily. But I was wondering about your idea as well if what to do.
The password: `xsmtpsibe7b3a7c025dbe04d9bc71fb8203c20b4940c8fb37fbb0d021d194e78666d57db-WnvOEK1vG3cZrhkZ`

**Closes** #87 